### PR TITLE
connect: mux

### DIFF
--- a/connect-mux/config.go
+++ b/connect-mux/config.go
@@ -1,0 +1,56 @@
+package mux
+
+import "context"
+
+type config struct {
+	onConnected              func(ctx context.Context)
+	onDisconnected           func(ctx context.Context)
+	onBundleUpdated          func(ctx context.Context, key string)
+	onBootstrapConfigUpdated func(ctx context.Context)
+}
+
+type WatchOption func(*config)
+
+// WithOnConnected sets the callback for when the connection is established
+func WithOnConnected(onConnected func(context.Context)) WatchOption {
+	return func(cfg *config) {
+		cfg.onConnected = onConnected
+	}
+}
+
+// WithOnDisconnected sets the callback for when the connection is lost
+func WithOnDisconnected(onDisconnected func(context.Context)) WatchOption {
+	return func(cfg *config) {
+		cfg.onDisconnected = onDisconnected
+	}
+}
+
+// WithOnBundleUpdated sets the callback for when the bundle is updated
+func WithOnBundleUpdated(onBundleUpdated func(ctx context.Context, key string)) WatchOption {
+	return func(cfg *config) {
+		cfg.onBundleUpdated = onBundleUpdated
+	}
+}
+
+// WithOnBootstrapConfigUpdated sets the callback for when the bootstrap config is updated
+func WithOnBootstrapConfigUpdated(onBootstrapConfigUpdated func(context.Context)) WatchOption {
+	return func(cfg *config) {
+		cfg.onBootstrapConfigUpdated = onBootstrapConfigUpdated
+	}
+}
+
+func newConfig(opts ...WatchOption) *config {
+	cfg := &config{}
+	for _, opt := range []WatchOption{
+		WithOnConnected(func(_ context.Context) {}),
+		WithOnDisconnected(func(_ context.Context) {}),
+		WithOnBundleUpdated(func(_ context.Context, key string) {}),
+		WithOnBootstrapConfigUpdated(func(_ context.Context) {}),
+	} {
+		opt(cfg)
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg
+}

--- a/connect-mux/messages.go
+++ b/connect-mux/messages.go
@@ -1,0 +1,69 @@
+package mux
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pomerium/zero-sdk/connect"
+)
+
+// Watch watches for changes to the config until either context is cancelled,
+// or an error occurs while muxing
+func (svc *Mux) Watch(ctx context.Context, opts ...WatchOption) error {
+	cfg := newConfig(opts...)
+	return svc.mux.Receive(ctx, func(ctx context.Context, msg message) error {
+		return dispatch(ctx, cfg, msg)
+	})
+}
+
+func dispatch(ctx context.Context, cfg *config, msg message) error {
+	switch {
+	case msg.stateChange != nil:
+		switch *msg.stateChange {
+		case connected:
+			cfg.onConnected(ctx)
+		case disconnected:
+			cfg.onDisconnected(ctx)
+		default:
+			return fmt.Errorf("unknown state change")
+		}
+	case msg.Message != nil:
+		switch msg.Message.Message.(type) {
+		case *connect.Message_ConfigUpdated:
+			cfg.onBundleUpdated(ctx, "config")
+		case *connect.Message_BootstrapConfigUpdated:
+			cfg.onBootstrapConfigUpdated(ctx)
+		default:
+			return fmt.Errorf("unknown message type")
+		}
+	default:
+		return fmt.Errorf("unknown message payload")
+	}
+	return nil
+}
+
+type message struct {
+	*stateChange
+	*connect.Message
+}
+
+type stateChange string
+
+const (
+	connected    stateChange = "connected"
+	disconnected stateChange = "disconnected"
+)
+
+func (svc *Mux) onConnected(ctx context.Context) error {
+	s := connected
+	return svc.mux.Publish(ctx, message{stateChange: &s})
+}
+
+func (svc *Mux) onDisconnected(ctx context.Context) error {
+	s := disconnected
+	return svc.mux.Publish(ctx, message{stateChange: &s})
+}
+
+func (svc *Mux) onMessage(ctx context.Context, msg *connect.Message) error {
+	return svc.mux.Publish(ctx, message{Message: msg})
+}

--- a/connect-mux/service.go
+++ b/connect-mux/service.go
@@ -19,11 +19,11 @@ import (
 
 // Run starts the updates service, listening for updates from the cloud
 // until the context is canceled
-func Start(ctx context.Context, client connect.ConnectClient) *Mux {
+func Start(ctx context.Context, client connect.ConnectClient, opts ...fanout.Option) *Mux {
 	ctx, cancel := context.WithCancelCause(ctx)
 	svc := &Mux{
 		client: client,
-		mux:    fanout.Start[message](ctx),
+		mux:    fanout.Start[message](ctx, opts...),
 	}
 	go svc.run(ctx, cancel)
 	return svc
@@ -42,7 +42,7 @@ func (svc *Mux) run(ctx context.Context, cancel context.CancelCauseFunc) {
 	bo := backoff.NewExponentialBackOff()
 	bo.MaxElapsedTime = 0
 
-	delay := time.Duration(1)
+	delay := time.Duration(time.Microsecond)
 
 loop:
 	for {

--- a/connect-mux/service.go
+++ b/connect-mux/service.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/rs/zerolog"
@@ -29,6 +30,8 @@ func Start(ctx context.Context, client connect.ConnectClient) *Mux {
 type Mux struct {
 	client connect.ConnectClient
 	mux    *fanout.FanOut[message]
+
+	connected atomic.Bool
 }
 
 // run does not do any kind of backoff

--- a/connect-mux/service.go
+++ b/connect-mux/service.go
@@ -36,21 +36,18 @@ type Mux struct {
 	connected atomic.Bool
 }
 
-// run does not do any kind of backoff
-// due to service having a ttl constraint on the server side,
-// thus we want to reconnect as soon as possible
 func (svc *Mux) run(ctx context.Context, cancel context.CancelCauseFunc) {
 	logger := log.Ctx(ctx).With().Str("service", "connect-mux").Logger().Level(zerolog.DebugLevel)
 
 	bo := backoff.NewExponentialBackOff()
 	bo.MaxElapsedTime = 0
 
-	delay := time.Duration(0)
+	delay := time.Duration(1)
 
 loop:
 	for {
 		if delay > 0 {
-			log.Ctx(ctx).Debug().Str("delay", delay.String()).Msg("backoff")
+			log.Ctx(ctx).Info().Str("delay", delay.String()).Msg("backoff")
 		}
 
 		select {

--- a/connect-mux/service.go
+++ b/connect-mux/service.go
@@ -1,0 +1,92 @@
+// Package mux provides the way to listen for updates from the cloud
+package mux
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+
+	"github.com/pomerium/zero-sdk/connect"
+	"github.com/pomerium/zero-sdk/fanout"
+)
+
+// Run starts the updates service, listening for updates from the cloud
+// until the context is canceled
+func Start(ctx context.Context, client connect.ConnectClient) *Mux {
+	ctx, cancel := context.WithCancelCause(ctx)
+	svc := &Mux{
+		client: client,
+		mux:    fanout.Start[message](ctx),
+	}
+	go svc.run(ctx, cancel)
+	return svc
+}
+
+type Mux struct {
+	client connect.ConnectClient
+	mux    *fanout.FanOut[message]
+}
+
+// run does not do any kind of backoff
+// due to service having a ttl constraint on the server side,
+// thus we want to reconnect as soon as possible
+func (svc *Mux) run(ctx context.Context, cancel context.CancelCauseFunc) {
+	logger := log.Ctx(ctx).With().Str("service", "connect-mux").Logger().Level(zerolog.DebugLevel)
+
+	for ctx.Err() == nil {
+		err := svc.subscribeAndDispatch(ctx)
+		if err != nil {
+			logger.Err(err).Msg("running")
+		}
+		if errors.Is(err, nonRetryableError{}) {
+			cancel(err)
+			return
+		}
+	}
+	cancel(fmt.Errorf("connect-mux run: %w", context.Cause(ctx)))
+}
+
+type nonRetryableError struct {
+	error
+}
+
+func (e nonRetryableError) Is(target error) bool {
+	//nolint:errorlint // we want to check for the exact type
+	_, ok := target.(nonRetryableError)
+	return ok
+}
+
+func (svc *Mux) subscribeAndDispatch(ctx context.Context) (err error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	stream, err := svc.client.Subscribe(ctx, &connect.SubscribeRequest{})
+	if err != nil {
+		return fmt.Errorf("subscribe: %w", err)
+	}
+
+	if err = svc.onConnected(ctx); err != nil {
+		return fmt.Errorf("on connected: %w", err)
+	}
+	defer func() {
+		err = multierror.Append(
+			err,
+			nonRetryableError{svc.onDisconnected(ctx)},
+		).ErrorOrNil()
+	}()
+
+	for {
+		msg, err := stream.Recv()
+		if err != nil {
+			return fmt.Errorf("receive: %w", err)
+		}
+		err = svc.onMessage(ctx, msg)
+		if err != nil {
+			return nonRetryableError{fmt.Errorf("on message: %w", err)}
+		}
+	}
+}

--- a/fanout/fanout.go
+++ b/fanout/fanout.go
@@ -22,8 +22,8 @@ type FanOut[T any] struct {
 	subscribers chan *subscriber[T]
 }
 
-// New creates and runs a new FanOut
-func New[T any](ctx context.Context, opts ...Option) *FanOut[T] {
+// Start creates and runs a new FanOut
+func Start[T any](ctx context.Context, opts ...Option) *FanOut[T] {
 	cfg := defaultFanOutConfig()
 	cfg.apply(opts...)
 

--- a/fanout/fanout_test.go
+++ b/fanout/fanout_test.go
@@ -20,7 +20,7 @@ func TestFanOutStopped(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	f := fanout.New[int](ctx, fanout.WithPublishTimeout(time.Millisecond*10))
+	f := fanout.Start[int](ctx, fanout.WithPublishTimeout(time.Millisecond*10))
 	assert.Eventually(t, func() bool {
 		return errors.Is(f.Publish(context.Background(), 1), fanout.ErrStopped)
 	}, 5*time.Second, 10*time.Millisecond)
@@ -38,7 +38,7 @@ func TestFanOutEvictSlowSubscriber(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	t.Cleanup(cancel)
 
-	f := fanout.New[int](ctx,
+	f := fanout.Start[int](ctx,
 		fanout.WithReceiverBufferSize(1),
 		fanout.WithReceiverCallbackTimeout(timeout),
 	)
@@ -85,7 +85,7 @@ func TestFanOutReceiverCancelOnError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	f := fanout.New[int](ctx)
+	f := fanout.Start[int](ctx)
 	receiverErr := errors.New("receiver error")
 	errch := make(chan error, 1)
 
@@ -107,7 +107,7 @@ func TestFanOutFilter(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	t.Cleanup(cancel)
 
-	f := fanout.New[int](ctx)
+	f := fanout.Start[int](ctx)
 	ready := make(chan struct{})
 	results := make(chan int)
 	go func() {
@@ -137,7 +137,7 @@ func BenchmarkFanout(b *testing.B) {
 
 	cycles := 1
 
-	f := fanout.New[int](ctx)
+	f := fanout.Start[int](ctx)
 	errStopReceiver := errors.New("stop receiver")
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.SetLimit(-1)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,10 @@ require (
 	github.com/bufbuild/buf v1.25.0
 	github.com/deepmap/oapi-codegen v1.13.2
 	github.com/go-chi/chi/v5 v5.0.10
+	github.com/hashicorp/go-multierror v1.1.1
+	github.com/rs/zerolog v1.30.0
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/sync v0.3.0
 	google.golang.org/grpc v1.57.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0
 	google.golang.org/protobuf v1.31.0
@@ -49,6 +52,7 @@ require (
 	github.com/google/go-containerregistry v0.15.2 // indirect
 	github.com/google/pprof v0.0.0-20230705174524-200ffdc848b8 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/yaml v0.1.0 // indirect
 	github.com/jdxcode/netrc v0.0.0-20221124155335-4616370d1a84 // indirect
@@ -100,7 +104,6 @@ require (
 	golang.org/x/crypto v0.11.0 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.12.0 // indirect
-	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.10.0 // indirect
 	golang.org/x/term v0.10.0 // indirect
 	golang.org/x/text v0.11.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/bufbuild/buf v1.25.0
+	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/deepmap/oapi-codegen v1.13.2
 	github.com/go-chi/chi/v5 v5.0.10
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/bufbuild/protocompile v0.5.1/go.mod h1:G5iLmavmF4NsYtpZFvE3B/zFch2GIY
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.9.1 h1:6iJ6NqdoxCDr6mbY8h18oSO+cShGSMRGCEo7F2h0x8s=
 github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=
+github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
+github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F32mSOjUmXrMHnKwZdA8wcEefY7UVqBKYGjpdQY=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 h1:qSGYFH7+jGhDF8vLC+iwCD4WpbV1EBDSzWkJODFLams=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,7 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/containerd/stargz-snapshotter/estargz v0.14.3 h1:OqlDCK3ZVUO6C3B/5FSkDwbkEETK84kQgEeFwDC+62k=
 github.com/containerd/stargz-snapshotter/estargz v0.14.3/go.mod h1:KY//uOCIkSuNAHhJogcZtrNHdKrA99/FCCRjE3HD36o=
+github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -81,6 +82,7 @@ github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
 github.com/gofrs/uuid/v5 v5.0.0 h1:p544++a97kEL+svbcFbCQVM9KFu0Yo25UoISXGNNH9M=
 github.com/gofrs/uuid/v5 v5.0.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
@@ -101,6 +103,10 @@ github.com/google/pprof v0.0.0-20230705174524-200ffdc848b8/go.mod h1:Jh3hGz2jkYa
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
@@ -141,6 +147,7 @@ github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
+github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
@@ -181,6 +188,9 @@ github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDN
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/rs/cors v1.9.0 h1:l9HGsTsHJcvW14Nk7J9KFz8bzeAWXn3CG6bgt7LsrAE=
 github.com/rs/cors v1.9.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/rs/zerolog v1.30.0 h1:SymVODrcRsaRaSInD9yQtKbtWqwsfoPcRff/oRXLj4c=
+github.com/rs/zerolog v1.30.0/go.mod h1:/tk+P47gFdPXq4QYjvCmT5/Gsug2nagsFWBWhAiSi1w=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=


### PR DESCRIPTION
We want to maintain a single connection to the Connect server. 
`connect-mux` allows multiple update subscribers to listen to updates arriving via Connect service, sharing the underlying gRPC connection.


